### PR TITLE
Fix `undefined case_id` error 

### DIFF
--- a/jobs/PROD/f1-1.sendReferralsToPrimero.js
+++ b/jobs/PROD/f1-1.sendReferralsToPrimero.js
@@ -51,7 +51,7 @@ each(
     state.serviceMap = serviceMap;
 
     const serviceMapArray = [];
-    for (service in serviceMap) serviceMapArray.push(service);
+    for (const service in serviceMap) serviceMapArray.push(service);
     if (!serviceMapArray.includes(progres_description)) {
       throw new Error(
         `Service value shared is not an accepted UNICEF service type. Please see the mapping specifications.`
@@ -219,6 +219,7 @@ each(
         remote: true,
         unhcr_individual_no: data['individuals.progres_id'],
       },
+      {},
       next => {
         if (next.data.length === 0) {
           return createCase({ data: body }, resp => {

--- a/jobs/PROD/f1-1.sendReferralsToPrimero.js
+++ b/jobs/PROD/f1-1.sendReferralsToPrimero.js
@@ -51,7 +51,7 @@ each(
     state.serviceMap = serviceMap;
 
     const serviceMapArray = [];
-    for (const service in serviceMap) serviceMapArray.push(service);
+    for (service in serviceMap) serviceMapArray.push(service);
     if (!serviceMapArray.includes(progres_description)) {
       throw new Error(
         `Service value shared is not an accepted UNICEF service type. Please see the mapping specifications.`
@@ -219,7 +219,6 @@ each(
         remote: true,
         unhcr_individual_no: data['individuals.progres_id'],
       },
-      {},
       next => {
         if (next.data.length === 0) {
           return createCase({ data: body }, resp => {

--- a/jobs/PROD/f1-4.sendSuccessToDTP.js
+++ b/jobs/PROD/f1-4.sendSuccessToDTP.js
@@ -2,17 +2,27 @@ alterState(state => {
   const { configuration } = state;
   const { urlDTP, key, cert } = configuration;
 
-  const primero_user = state.data.owned_by || state.references[1][0].owned_by;
+  const pluckFromReference = (index, value) =>
+    index ? index[value] : 'Not defined';
+
+  const primero_user =
+    state.data.owned_by ||
+    pluckFromReference(state.references[1][0], 'owned_by');
+
   const data = {
     status: 'Pending Acknowledgement',
     primero_user,
-    case_id: state.references[1][0].case_id || state.references[1][0].id,
+    case_id:
+      state.data.case_id ||
+      pluckFromReference(state.references[1][0], 'case_id') ||
+      pluckFromReference(state.references[1][0], 'id'),
     progres_interventionnumber: state.references[0].progres_interventionnumber,
   };
 
   console.log(
     `Sending success message to DTP for case_id ${data.case_id} and progres_interventionnumber ${data.progres_interventionnumber}`
   );
+
   return http
     .post({
       url: urlDTP,


### PR DESCRIPTION
Ref #72 - fixes bug reported on production causing notification to Progres to fail (which should be sent after new case is created successfully in Primero)

### Approach
I have made some changes that first check if `case_id` is in `state.data`  because if the previous job created a case then the `case_id` will be in `state.data` and not `references` array. Also i added a helper that will check if an `index` in a `references` array exist before returning the value. This solves the problem of having `undefined` `case_id, owner_id or id`. If the `index` does not exist then the returned value will be `'Not defined'`
