### PR TITLE
revert service value shared

### DIFF
--- a/jobs/PROD/f1-1.sendReferralsToPrimero.js
+++ b/jobs/PROD/f1-1.sendReferralsToPrimero.js
@@ -53,7 +53,7 @@ each(
     const serviceMapArray = Object.keys(serviceMap);
 
     if (!serviceMapArray.includes(progres_description)) {
-      const errMessage = `Service '${progres_description}' with progres_interventionnumber '${data.progres_interventionnumber}'`;
+      const errMessage = `Service value shared (${progres_description}) with progres_interventionnumber '${data.progres_interventionnumber}'`;
       throw new Error(
         `${errMessage} is not an accepted UNICEF service type.\n\tPlease see the mapping specifications.`
       );


### PR DESCRIPTION
### Summary
For sending errors to DTP, the `jobs/PROD/f1-3.sendErrorToDTP.js` looks for `Service value shared` keyword which was previously modified in this PR #72, These changes reverts that behavior  